### PR TITLE
merge main and develop for v0.2.1

### DIFF
--- a/include/util.hpp
+++ b/include/util.hpp
@@ -45,6 +45,9 @@ public:
   // Destructor
   ~TokenBucket();
 
+  TokenBucket(const TokenBucket&) = delete;
+  TokenBucket& operator=(const TokenBucket&) = delete;
+
   // Consume token
   void consume();
 
@@ -67,6 +70,9 @@ public:
   explicit File(std::string path);
 
   ~File();
+
+  File(const File&) = delete;
+  File& operator=(const File&) = delete;
 
   void keep_file();
 
@@ -123,10 +129,10 @@ public:
 private:
   std::optional<std::string> gid;
   std::string name;
-  float progress;
+  float progress{0};
   bool completion_status;
 };
 
-void print_progress_bar(const std::vector<FileDownloadProgress>& files, size_t bar_width = 40);
+void print_progress_bar(const std::vector<FileDownloadProgress>& files, size_t max_length, size_t bar_width = 40);
 
 } // namespace util

--- a/src/api.cpp
+++ b/src/api.cpp
@@ -79,9 +79,13 @@ std::optional<api::Torrent> api::RealDebridClient::send_magnet_link(const std::s
             std::string torrent_name = parsed_json.contains("filename") && parsed_json["filename"].is_string()
                                            ? parsed_json["filename"].get<std::string>()
                                            : "Unknown filename";
+            std::vector<std::string> file_names = files | std::ranges::views::transform([](const std::string& file) {
+                                                    auto position = file.substr(1).find('/');
+                                                    return position != std::string::npos ? file.substr(position + 2) : file;
+                                                  }) |
+                                                  std::ranges::to<std::vector>();
             auto size = parsed_json.contains("original_bytes") ? parsed_json["original_bytes"].get<int>() : 0;
-            api::Torrent torrent{generated_id, torrent_name, std::vector<std::string>{files.begin(), files.end()},
-                                 std::vector<std::string>{links.begin(), links.end()}, size};
+            api::Torrent torrent{generated_id, torrent_name, file_names, std::vector<std::string>{links.begin(), links.end()}, size};
             return torrent;
           }
         }
@@ -135,7 +139,7 @@ bool api::RealDebridClient::wait_for_status(const std::string& torrent_id, const
 
     std::this_thread::sleep_for(static_cast<std::chrono::seconds>(interval));
     if (interval < max_interval) {
-      interval = std::min(interval * 2, max_interval);
+      interval = std::min(static_cast<int>(interval * 1.2), max_interval);
     }
   }
   std::println("", desired_status);

--- a/src/aria2_manager.cpp
+++ b/src/aria2_manager.cpp
@@ -127,7 +127,7 @@ std::optional<std::string> aria2::rpc_add_download(const std::string& link) {
   if (response.status_code == 200) {
     auto parsed_json = json::parse(response.text);
     if (parsed_json.contains("result")) {
-      std::println("GID: {}", parsed_json["result"].get<std::string>());
+      // std::println("GID: {}", parsed_json["result"].get<std::string>());
       return parsed_json["result"].get<std::string>();
     }
   }

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -200,29 +200,29 @@ util::FileDownloadProgress::~FileDownloadProgress() {
   }
 }
 
-// TODO: Ensure consistent spacing between download name and progress bar
-void util::print_progress_bar(const std::vector<util::FileDownloadProgress>& files, size_t bar_width) {
+void util::print_progress_bar(const std::vector<util::FileDownloadProgress>& files, size_t max_length, size_t bar_width) {
   if (files.empty()) {
     return;
   }
-  auto max_length = std::ranges::max(files | std::views::transform([](const util::FileDownloadProgress& file) { return file.get_name().length(); }));
   for (const auto& file : files) {
-    size_t current_position = static_cast<size_t>(bar_width * file.get_progress());
+    if (file.get_progress() != 0 && !file.get_completion_status()) {
+      size_t current_position = static_cast<size_t>(bar_width * file.get_progress());
 
-    // Print filename left-aligned with a width of max_length
-    std::print("{:<{}}", file.get_name(), max_length);
+      // Print filename left-aligned with a width of max_length
+      std::print("{:<{}}", file.get_name(), max_length);
 
-    // Print progress bar
-    std::print(" [");
-    for (size_t i = 0; i < bar_width; ++i) {
-      if (i < current_position) {
-        std::print("=");
-      } else if (i == current_position) {
-        std::print(">");
-      } else {
-        std::print(" ");
+      // Print progress bar
+      std::print(" [");
+      for (size_t i = 0; i < bar_width; ++i) {
+        if (i < current_position) {
+          std::print("=");
+        } else if (i == current_position) {
+          std::print(">");
+        } else {
+          std::print(" ");
+        }
       }
+      std::println("] {}%", static_cast<size_t>(file.get_progress() * 100.0));
     }
-    std::println("] {}%", static_cast<size_t>(file.get_progress() * 100.0));
   }
 }


### PR DESCRIPTION
* fix: exclude redundant torrent name from individual file names
* fix(wip): show aggregate progress if number of files to download is above 10
* fix(wip): only show downloads that are currently in progress
* fix: only print downloads that are active
* fix: completed downloads indication offset by correct amount for alignment